### PR TITLE
Fix work item updates by including team in API URL

### DIFF
--- a/src/api/boards.ts
+++ b/src/api/boards.ts
@@ -179,6 +179,7 @@ export async function createWorkItem(
 export async function updateWorkItem(
   client: DevOpsClient,
   project: string,
+  team: string,
   id: number,
   fields: Record<string, string>,
 ): Promise<WorkItem> {
@@ -188,7 +189,7 @@ export async function updateWorkItem(
     value,
   }))
   return client.jsonPatch<WorkItem>(
-    `${project}/_apis/wit/workitems/${id}?api-version=7.1`,
+    `${project}/${team}/_apis/wit/workitems/${id}?api-version=7.1`,
     ops,
   )
 }

--- a/src/boards/WorkItemDialog.tsx
+++ b/src/boards/WorkItemDialog.tsx
@@ -57,7 +57,7 @@ export function WorkItemDialog({ client, project, team, item, board, onClose, on
       if (assignedTo !== (item.fields['System.AssignedTo']?.uniqueName ?? '')) {
         fields['System.AssignedTo'] = assignedTo
       }
-      const updated = await updateWorkItem(client, project, item.id, fields)
+      const updated = await updateWorkItem(client, project, team, item.id, fields)
       onUpdated(updated)
     } catch {
       setError('Failed to update work item')


### PR DESCRIPTION
Board fields (System.BoardColumn, System.BoardLane) require team context in the Azure DevOps API URL to resolve board column mappings correctly.