### PR TITLE
Add version number to sidebar (v2.1.3)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chargenodedevops",
-  "version": "0.0.0",
+  "version": "2.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chargenodedevops",
-      "version": "0.0.0",
+      "version": "2.1.3",
       "dependencies": {
         "@mdi/js": "^7.4.47",
         "@mdi/react": "^1.6.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chargenodedevops",
   "private": true,
-  "version": "0.0.0",
+  "version": "2.1.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.css
+++ b/src/App.css
@@ -67,6 +67,14 @@
   flex-shrink: 0;
 }
 
+.nav-version {
+  margin-top: auto;
+  padding: 8px;
+  font-size: 10px;
+  color: #aaa;
+  text-align: center;
+}
+
 .nav-btn {
   padding: 12px;
   border: none;
@@ -269,5 +277,8 @@
   .btn-action-primary {
     background: #1EBE69;
     color: white;
+  }
+  .nav-version {
+    color: #555;
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -81,6 +81,7 @@ function App() {
             <Icon path={mdiRocketLaunch} size={1} />
             <span className="nav-label">Releases</span>
           </button>
+          <span className="nav-version">v{__APP_VERSION__}</span>
         </nav>
         <main className="content">
         {tab === 'boards' && client && <BoardView client={client} project={selectedProject} />}

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -1,0 +1,1 @@
+declare const __APP_VERSION__: string

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,14 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { readFileSync } from 'node:fs'
+
+const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'))
 
 // https://vite.dev/config/
 export default defineConfig({
   base: '/ChargeNodeDevOps/',
   plugins: [react()],
+  define: {
+    __APP_VERSION__: JSON.stringify(pkg.version),
+  },
 })


### PR DESCRIPTION
Display app version at the bottom of the left navigation sidebar. Version is injected from package.json via Vite define at build time.

https://claude.ai/code/session_01VmqG5RH1Bt3kpsTzEfVthM